### PR TITLE
Fix JavaScript error when using TagsInputWidget

### DIFF
--- a/tags_input/widgets.py
+++ b/tags_input/widgets.py
@@ -80,10 +80,10 @@ class TagsInputWidget(TagsInputWidgetBase):
         enable_jquery = getattr(settings, 'TAGS_INPUT_INCLUDE_JQUERY', True)
         if enable_jquery:  # pragma: no cover
             css['all'] += 'css/base/jquery.ui.all.css',
-            js += (
+            js = (
                 'js/jquery-1.7.2.min.js',
                 'js/jquery-ui-18.1.16.min.js',
-            )
+            ) + js
 
 
 class AdminTagsInputWidget(widgets.FilteredSelectMultiple,


### PR DESCRIPTION
When using a `TagsInputField` in a form and `TAGS_INPUT_INCLUDE_JQUERY` is enabled, Chome on OS X throws this JavaScript error:

```
Uncaught TypeError: Object [object Object] has no method 'tagsInput'
```

It's because the tagsinput plugin's script is loaded before jQuery itself is. Tweaking the `TagsInputWidget` class to make sure the plugin is loaded after jQuery fixes the issue.
