### PR TITLE
1.9 support. SortedDict replaced by OrderedDict

### DIFF
--- a/tags_input/views.py
+++ b/tags_input/views.py
@@ -1,4 +1,4 @@
-from django.db import models
+from django.apps import apps
 from django import http
 
 try:
@@ -14,7 +14,8 @@ def _filter_func(queryset, field, term):
 
 
 def autocomplete(request, app, model, fields):
-    model = models.get_model(app, model)
+    apps_config = apps.get_app_config(app)
+    model = apps_config.get_model(model)
     mapping = utils.get_mapping(model)
     fields = fields.split('-')
 
@@ -48,4 +49,3 @@ def autocomplete(request, app, model, fields):
         response = ''
 
     return http.HttpResponse(response, content_type='application/javascript')
-

--- a/tags_input/widgets.py
+++ b/tags_input/widgets.py
@@ -5,7 +5,7 @@ from django import forms
 from django.template.loader import render_to_string
 from django.core import urlresolvers
 from django.contrib.admin import widgets
-from django.utils import datastructures
+from collections import OrderedDict
 
 
 class TagsInputWidgetBase(forms.SelectMultiple):
@@ -42,7 +42,7 @@ class TagsInputWidgetBase(forms.SelectMultiple):
                 if isinstance(v, six.integer_types):
                     ids.append(v)
 
-            values_map = datastructures.OrderedDict(map(
+            values_map = OrderedDict(map(
                 join_func,
                 self.mapping['queryset']
                 .filter(pk__in=ids)
@@ -102,4 +102,3 @@ class AdminTagsInputWidget(widgets.FilteredSelectMultiple,
             'js/jquery-ui-18.1.16.min.js',
             'js/jquery.tagsinput.js',
         ))
-

--- a/tags_input/widgets.py
+++ b/tags_input/widgets.py
@@ -42,7 +42,7 @@ class TagsInputWidgetBase(forms.SelectMultiple):
                 if isinstance(v, six.integer_types):
                     ids.append(v)
 
-            values_map = datastructures.SortedDict(map(
+            values_map = datastructures.OrderedDict(map(
                 join_func,
                 self.mapping['queryset']
                 .filter(pk__in=ids)


### PR DESCRIPTION
SortedDict itself is deprecated in Django 1.7, and will be removed in Django 1.9.

Now that Django only supports Python 2.7+, the correct fix is to use collections.OrderedDict instead of SortedDict.

A bit more detailed in [documentation](https://code.djangoproject.com/wiki/SortedDict)