### PR TITLE
Add check for tag_fields attribute on ModelAdmin in TagsInputMixin

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -109,7 +109,10 @@ Admin usage
     from tags_input import admin as tags_input_admin
 
     class YourAdmin(tags_input_admin.TagsInputAdmin):
-        pass
+        
+        #Optionally specify which ManyToMany fields are to be used for tagging
+        #Or define a get_tag_fields() method
+        tag_fields = ["some_field"]
 
     admin.site.register(models.YourModel, YourAdmin)
 

--- a/tags_input/admin.py
+++ b/tags_input/admin.py
@@ -6,6 +6,14 @@ from . import widgets
 
 class TagsInputMixin(object):
 
+    def get_tag_fields(self):
+        """Get a list fo fields on this model that could be potentially tagged.
+        
+        By default reads self.tag_fields if it exists of returns None for default behavious.
+        """
+        return getattr(self,"tag_fields",None)
+
+    
     def formfield_for_manytomany(self, db_field, request=None, **kwargs):
         '''
         Get a form Field for a ManyToManyField.
@@ -14,6 +22,11 @@ class TagsInputMixin(object):
         # a field in admin.
         if not db_field.rel.through._meta.auto_created:
             return None
+
+        #Ifthere is a list of taggable fields, and this filed isn't one of them, then fall back to parent method.
+        tag_fields=self.get_tag_fields()
+        if tag_fields is not None and db_field.name not in tag_fields:
+            return super(TagsInputMixin,self).formfield_for_manytomany(db_field, request, **kwargs)
 
         queryset = db_field.rel.to._default_manager.get_queryset()
 


### PR DESCRIPTION
I've added my tweak to TagsInputMixin. Supplies a new method get_tags_input() that by default just tries to read the attribute tag_fields. If that isn't defined, the method returns None. formfield_for_manytomany then calls get_tag_fields and if the result isn't None and the db_field isn't in the returned value, then formfield_for_manytomany reverts to the parent method.

I've updated the README, but you might prefer just to have it in the docs (sorry didn't touch them!)